### PR TITLE
Add item revalidation queue and caching; lazy-load sessions and cache user settings

### DIFF
--- a/app/components/header/menu.vue
+++ b/app/components/header/menu.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
-const { auth, session, sessions, revoke } = useAuth()
+const { auth, session, sessions, getSessions, revoke } = useAuth()
 const toast = useToast()
 const colorMode = useColorMode()
 const login = useLoginModal()
 const feedback = useFeedbackModal()
 const { t, locales, setLocale } = useI18n()
+const open = ref(false)
+
+watch(open, async (value) => {
+    if (value && session.value && sessions.value === undefined) await getSessions()
+})
 
 const switchAccount = async (sessionToken: string) => {
     await auth.multiSession.setActive({ sessionToken })
@@ -21,6 +26,7 @@ const switchAccount = async (sessionToken: string) => {
 
 <template>
     <UDropdownMenu
+        v-model:open="open"
         :items="[
             [
                 {

--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -131,8 +131,9 @@ const _useAuth = () => {
         revoke,
     }
 
-    // Create initialization promise that waits for session and sessions data
-    const initPromise = Promise.all([getSession(), getSessions()]).then(() => returnObject)
+    // Create initialization promise that waits for the active session only.
+    // Device sessions are loaded lazily by UI that needs account switching.
+    const initPromise = getSession().then(() => returnObject)
 
     // Merge promise with return object (same pattern as Nuxt's useFetch/useAsyncData)
     const awaitableResult = Object.assign(initPromise, returnObject)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,6 +21,10 @@ const description = 'アバター改変レシピの共有プラットフォー�
 
 const availableI18nLocales = ['en']
 
+const cloudflareObservabilityHeadSamplingRate = Number(
+    process.env.CLOUDFLARE_OBSERVABILITY_HEAD_SAMPLING_RATE ?? 1,
+)
+
 const normalizeRuntimeConfigForVitest = () => {
     if (!isVitest) return
 
@@ -162,7 +166,9 @@ export default defineNuxtConfig({
                 ],
                 observability: {
                     enabled: true,
-                    head_sampling_rate: 1,
+                    head_sampling_rate: Number.isFinite(cloudflareObservabilityHeadSamplingRate)
+                        ? cloudflareObservabilityHeadSamplingRate
+                        : 1,
                 },
                 account_id: env.CLOUDFLARE_ACCOUNT_ID,
                 d1_databases: [
@@ -193,6 +199,22 @@ export default defineNuxtConfig({
                 ],
                 triggers: {
                     crons: ['0 22 * * *'],
+                },
+                queues: {
+                    producers: [
+                        {
+                            queue: 'item-revalidation',
+                            binding: 'ITEM_REVALIDATION_QUEUE',
+                        },
+                    ],
+                    consumers: [
+                        {
+                            queue: 'item-revalidation',
+                            max_batch_size: 10,
+                            max_batch_timeout: 5,
+                            max_retries: 3,
+                        },
+                    ],
                 },
             },
         },

--- a/server/api/items/owned-avatars.get.ts
+++ b/server/api/items/owned-avatars.get.ts
@@ -9,11 +9,8 @@ const query = z.object({
         .default(OWNED_AVATARS_API_DEFAULT_LIMIT),
 })
 
-export default authedSessionEventHandler<Item[]>(async ({ session, db }) => {
+export default authedSessionEventHandler<Item[]>(async ({ event, session, db }) => {
     const { limit } = await validateQuery(query)
-
-    const oneDayAgo = new Date()
-    oneDayAgo.setDate(oneDayAgo.getDate() - 1)
 
     const data = await db.query.items.findMany({
         where: {
@@ -21,7 +18,7 @@ export default authedSessionEventHandler<Item[]>(async ({ session, db }) => {
             category: { eq: 'avatar' },
             setupItems: {
                 setup: {
-                    userId: { eq: session!.user.id },
+                    userId: { eq: session.user.id },
                 },
             },
         },
@@ -31,42 +28,9 @@ export default authedSessionEventHandler<Item[]>(async ({ session, db }) => {
         limit,
     })
 
-    // 1日以上古いアイテムのみフィルタリング
-    const outdatedItems = data.filter((item) => item.updatedAt < oneDayAgo)
+    await Promise.all(
+        data.map((item) => enqueueItemRevalidation(event, item, 'owned-avatars')),
+    )
 
-    // 古いアイテムを並列で更新（エラーハンドリング改善）
-    const updatePromises = outdatedItems.map(async (item) => {
-        try {
-            // $fetchの使用を修正
-            const response = await $fetch<Item>(`/api/items/${item.id}`)
-            console.log(`Updated item ${item.id} from external API`)
-            return { ...item, ...response }
-        } catch (error) {
-            console.error(`Failed to update item ${item.id}:`, error)
-            return item // エラーの場合は元のデータを返す
-        }
-    })
-
-    // 並列実行がある場合のみ待機
-    const updatedItems = updatePromises.length > 0 ? await Promise.allSettled(updatePromises) : []
-
-    // Promise.allSettledの結果を処理
-    const updatedItemsMap = new Map<string, Item>()
-    updatedItems.forEach((result, index) => {
-        if (result.status === 'fulfilled') {
-            const item = result.value
-            updatedItemsMap.set(item.id, item)
-        } else {
-            // rejected の場合は元のアイテムを使用
-            const originalItem = outdatedItems[index]
-            if (originalItem) {
-                updatedItemsMap.set(originalItem.id, originalItem)
-            }
-        }
-    })
-
-    // 結果をマッピング
-    const result = data.map((item) => updatedItemsMap.get(item.id) || item)
-
-    return result
+    return data
 })

--- a/server/api/items/owned-avatars.get.ts
+++ b/server/api/items/owned-avatars.get.ts
@@ -28,9 +28,10 @@ export default authedSessionEventHandler<Item[]>(async ({ event, session, db }) 
         limit,
     })
 
-    await Promise.all(
-        data.map((item) => enqueueItemRevalidation(event, item, 'owned-avatars')),
-    )
+    if (data.length)
+        runAfterResponse(
+            Promise.all(data.map((item) => enqueueItemRevalidation(event, item, 'owned-avatars'))),
+        )
 
     return data
 })

--- a/server/api/items/popular-avatars.get.ts
+++ b/server/api/items/popular-avatars.get.ts
@@ -10,30 +10,40 @@ const query = z.object({
         .default(POPULAR_AVATARS_API_DEFAULT_LIMIT),
 })
 
+const getPopularAvatars = defineCachedFunction(
+    async (db: ReturnType<typeof useDB>, limit: number) => {
+        return await db.query.items.findMany({
+            where: {
+                outdated: { eq: false },
+                category: { eq: 'avatar' },
+                setupItems: {
+                    setup: {
+                        public: { eq: true },
+                    },
+                },
+            },
+            orderBy: (t) => sql`(SELECT COUNT(*) FROM setup_items WHERE item_id = ${t.id}) DESC`,
+            limit,
+            columns: {
+                id: true,
+                platform: true,
+                name: true,
+                niceName: true,
+                image: true,
+                nsfw: true,
+            },
+        })
+    },
+    {
+        name: 'popular-avatars',
+        maxAge: 60 * 60 * 24,
+        getKey: (_db, limit) => String(limit),
+        swr: false,
+    },
+)
+
 export default promiseEventHandler(async ({ db }) => {
     const { limit } = await validateQuery(query)
 
-    const data = await db.query.items.findMany({
-        where: {
-            outdated: { eq: false },
-            category: { eq: 'avatar' },
-            setupItems: {
-                setup: {
-                    public: { eq: true },
-                },
-            },
-        },
-        orderBy: (t) => sql`(SELECT COUNT(*) FROM setup_items WHERE item_id = ${t.id}) DESC`,
-        limit,
-        columns: {
-            id: true,
-            platform: true,
-            name: true,
-            niceName: true,
-            image: true,
-            nsfw: true,
-        },
-    })
-
-    return data
+    return await getPopularAvatars(db, limit)
 })

--- a/server/api/setups/[id]/index.get.ts
+++ b/server/api/setups/[id]/index.get.ts
@@ -155,6 +155,7 @@ export default sessionEventHandler<Setup>(async ({ event, session, db }) => {
             if (!data) throw serverError.notFound()
 
             const items: SetupItem[] = []
+            const revalidationTasks: Promise<unknown>[] = []
             let failedItemsCount = 0
 
             for (const setupItem of data.items) {
@@ -163,7 +164,9 @@ export default sessionEventHandler<Setup>(async ({ event, session, db }) => {
                     continue
                 }
 
-                await enqueueItemRevalidation(event, setupItem.item, 'setup-detail')
+                revalidationTasks.push(
+                    enqueueItemRevalidation(event, setupItem.item, 'setup-detail'),
+                )
 
                 items.push({
                     id: setupItem.item.id,
@@ -182,6 +185,8 @@ export default sessionEventHandler<Setup>(async ({ event, session, db }) => {
                     shapekeys: setupItem.shapekeys,
                 })
             }
+
+            if (revalidationTasks.length) runAfterResponse(Promise.all(revalidationTasks))
 
             return {
                 ...data,

--- a/server/api/setups/[id]/index.get.ts
+++ b/server/api/setups/[id]/index.get.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
 
-const log = logger('/api/setups/[id]:GET')
-
 const params = z.object({
     id: z.string(),
 })
@@ -156,32 +154,34 @@ export default sessionEventHandler<Setup>(async ({ event, session, db }) => {
 
             if (!data) throw serverError.notFound()
 
-            const results = await Promise.all(
-                data.items.map(async (item) => {
-                    if (item.item.outdated) return null
-                    try {
-                        const response = await getItem(event, db, item.item.id, item.item.platform)
-                        if (response.outdated) return null
-                        return {
-                            ...response,
-                            category: item.category || response.category,
-                            unsupported: item.unsupported,
-                            note: item.note,
-                            shapekeys: item.shapekeys,
-                        }
-                    } catch (error) {
-                        log.error(`Failed to fetch item ${item.item.id}:`, error)
-                        return null
-                    }
-                }),
-            )
-
             const items: SetupItem[] = []
             let failedItemsCount = 0
 
-            for (const result of results)
-                if (result) items.push(result)
-                else failedItemsCount++
+            for (const setupItem of data.items) {
+                if (setupItem.item.outdated) {
+                    failedItemsCount++
+                    continue
+                }
+
+                await enqueueItemRevalidation(event, setupItem.item, 'setup-detail')
+
+                items.push({
+                    id: setupItem.item.id,
+                    platform: setupItem.item.platform,
+                    category: setupItem.category || setupItem.item.category,
+                    name: setupItem.item.name,
+                    niceName: setupItem.item.niceName,
+                    image: setupItem.item.image,
+                    price: setupItem.item.price,
+                    likes: setupItem.item.likes,
+                    nsfw: setupItem.item.nsfw,
+                    outdated: setupItem.item.outdated,
+                    shop: setupItem.item.shop,
+                    unsupported: setupItem.unsupported,
+                    note: setupItem.note,
+                    shapekeys: setupItem.shapekeys,
+                })
+            }
 
             return {
                 ...data,

--- a/server/api/users/me/settings.put.ts
+++ b/server/api/users/me/settings.put.ts
@@ -19,6 +19,8 @@ export default authedSessionEventHandler(
                 set: body,
             })
 
+        await purgeUserSettingsSessionCache(session.user.id)
+
         return { success: true }
     },
     { rejectBannedUser: true },

--- a/server/middleware/maintenance.ts
+++ b/server/middleware/maintenance.ts
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     if (ignoredMaintenancePaths.some((prefix) => path.startsWith(prefix))) return
 
     try {
-        const { isMaintenance } = await getAppFlags()
+        const isMaintenance = await getMaintenanceFlag()
 
         if (isMaintenance && path !== '/on-maintenance')
             return sendRedirect(event, '/on-maintenance', 307)

--- a/server/plugins/itemRevalidationQueue.ts
+++ b/server/plugins/itemRevalidationQueue.ts
@@ -14,7 +14,6 @@ export default defineNitroPlugin((nitroApp) => {
                     await handleItemRevalidationMessage(message.body)
                     message.ack()
                 } catch (error) {
-                    await clearItemRevalidationLock(message.body)
                     log.error('Failed to revalidate item from queue:', error)
                     message.retry()
                 }

--- a/server/plugins/itemRevalidationQueue.ts
+++ b/server/plugins/itemRevalidationQueue.ts
@@ -1,0 +1,23 @@
+import type { MessageBatch } from '@cloudflare/workers-types'
+import type { ItemRevalidationMessage } from '../utils/itemRevalidationQueue'
+
+const log = logger('itemRevalidationQueue')
+
+export default defineNitroPlugin((nitroApp) => {
+    nitroApp.hooks.hook(
+        'cloudflare:queue',
+        async ({ batch }: { batch: MessageBatch<ItemRevalidationMessage> }) => {
+            if (batch.queue !== 'item-revalidation') return
+
+            for (const message of batch.messages)
+                try {
+                    await handleItemRevalidationMessage(message.body)
+                    message.ack()
+                } catch (error) {
+                    await clearItemRevalidationLock(message.body)
+                    log.error('Failed to revalidate item from queue:', error)
+                    message.retry()
+                }
+        },
+    )
+})

--- a/server/utils/appFlags.ts
+++ b/server/utils/appFlags.ts
@@ -2,6 +2,12 @@ import { z } from 'zod'
 
 const FLAGS_KEY = 'app'
 
+let maintenanceFlagCache: { value: boolean; expiresAt: number } | null = null
+
+export const clearMaintenanceFlagCache = () => {
+    maintenanceFlagCache = null
+}
+
 export const defaultAppFlags = {
     allowedBoothCategoryId: [],
     forceUpdateItem: false,
@@ -52,6 +58,19 @@ export const getAppFlags = defineCachedFunction(
     },
 )
 
+export const getMaintenanceFlag = async () => {
+    const now = Date.now()
+    if (maintenanceFlagCache && maintenanceFlagCache.expiresAt > now)
+        return maintenanceFlagCache.value
+
+    const { isMaintenance } = await getAppFlags()
+    maintenanceFlagCache = {
+        value: isMaintenance,
+        expiresAt: now + APP_FLAGS_CACHE_TTL * 1000,
+    }
+    return isMaintenance
+}
+
 export const updateAppFlags = async (patch: unknown) => {
     const parsedPatch = appFlagsPatchSchema.parse(patch)
     const current = await getAppFlags()
@@ -65,6 +84,7 @@ export const updateAppFlags = async (patch: unknown) => {
     })
 
     await useStorage('flags').setItem(FLAGS_KEY, next)
+    clearMaintenanceFlagCache()
     await useStorage('cache').del('nitro:functions:app-flags:.json')
     return next
 }

--- a/server/utils/eventHandler.ts
+++ b/server/utils/eventHandler.ts
@@ -8,6 +8,11 @@ const rejectBannedUser = (session: Session | null) => {
     if (session?.user?.banned) throw serverError.forbidden()
 }
 
+const hasBetterAuthSessionCookie = (headers: Headers) => {
+    const cookie = headers.get('cookie')
+    return Boolean(cookie?.includes('better-auth'))
+}
+
 export const promiseEventHandler = <T = unknown>(
     handler: ({ event, db }: { event: H3Event; db: ReturnType<typeof useDB> }) => Promise<T> | T,
 ) => {
@@ -30,7 +35,9 @@ export const sessionEventHandler = <T = unknown>(
     options?: SessionEventHandlerOptions,
 ) =>
     promiseEventHandler(async ({ event, db }) => {
-        const session = await auth.api.getSession({ headers: event.headers })
+        const session = hasBetterAuthSessionCookie(event.headers)
+            ? await auth.api.getSession({ headers: event.headers })
+            : null
 
         if (options?.rejectBannedUser) rejectBannedUser(session)
 

--- a/server/utils/getItem.ts
+++ b/server/utils/getItem.ts
@@ -12,7 +12,7 @@ import { joinURL, withHttps } from 'ufo'
 const log = logger('getItem')
 
 export default async (
-    event: H3Event,
+    event: H3Event | undefined,
     db: ReturnType<typeof useDB>,
     id: string,
     provider: Platform | undefined,
@@ -27,7 +27,7 @@ export default async (
         throw serverError.notFound({ responseMessage: 'Item not found or not allowed' })
 
     if (resolvedProvider === 'booth') {
-        const config = useRuntimeConfig(event)
+        const config = event ? useRuntimeConfig(event) : useRuntimeConfig()
         const proxyUrl = config.booth.proxyUrl
 
         if (!proxyUrl)

--- a/server/utils/itemRevalidationQueue.ts
+++ b/server/utils/itemRevalidationQueue.ts
@@ -1,0 +1,90 @@
+import type { H3Event } from 'h3'
+import type { Queue } from '@cloudflare/workers-types'
+const log = logger('itemRevalidationQueue')
+const QUEUE_BINDING = 'ITEM_REVALIDATION_QUEUE'
+const REVALIDATION_LOCK_TTL = 60 * 30
+
+type RuntimeEnv = Record<string, unknown>
+
+export interface ItemRevalidationMessage {
+    id: Item['id']
+    platform: Platform
+    reason: 'setup-detail' | 'owned-avatars'
+    requestedAt: string
+}
+
+const getRuntimeEnv = (event?: H3Event): RuntimeEnv => {
+    const g = globalThis as typeof globalThis & { __env__?: RuntimeEnv }
+    if (g.__env__) return g.__env__
+    return (event?.context.cloudflare?.env ?? process.env) as RuntimeEnv
+}
+
+const getQueue = (event?: H3Event) => getRuntimeEnv(event)[QUEUE_BINDING] as Queue | undefined
+
+const getLockKey = (id: Item['id'], platform: Platform) =>
+    `item-revalidation:${platform}:${encodeURIComponent(id)}`
+
+const shouldUseQueue = () => !import.meta.dev && process.env.NODE_ENV !== 'test'
+
+export const isItemRevalidationDue = (item: Pick<Item, 'platform' | 'updatedAt'>) => {
+    const maxAgeMs =
+        item.platform === 'github' ? GITHUB_ITEM_CACHE_DURATION_MS : ITEM_CACHE_DURATION_MS
+    return Date.now() - new Date(item.updatedAt).getTime() >= maxAgeMs
+}
+
+export const enqueueItemRevalidation = async (
+    event: H3Event,
+    item: Pick<Item, 'id' | 'platform' | 'updatedAt'>,
+    reason: ItemRevalidationMessage['reason'],
+) => {
+    if (!shouldUseQueue() || !isItemRevalidationDue(item)) return false
+
+    const queue = getQueue(event)
+    if (!queue) return false
+
+    const lockKey = getLockKey(item.id, item.platform)
+    const existingLock = await useStorage('cache').getItem(lockKey)
+    if (existingLock) return false
+
+    await useStorage('cache').setItem(lockKey, true, { ttl: REVALIDATION_LOCK_TTL })
+
+    try {
+        await queue.send({
+            id: item.id,
+            platform: item.platform,
+            reason,
+            requestedAt: new Date().toISOString(),
+        } satisfies ItemRevalidationMessage)
+        return true
+    } catch (error) {
+        await useStorage('cache').del(lockKey)
+        log.error('Failed to enqueue item revalidation:', error)
+        return false
+    }
+}
+
+export const handleItemRevalidationMessage = async (message: ItemRevalidationMessage) => {
+    const db = useDB()
+    await getItem(undefined, db, message.id, message.platform)
+
+    const relatedSetupItems = await db.query.setupItems.findMany({
+        where: {
+            itemId: { eq: message.id },
+        },
+        columns: {
+            setupId: true,
+        },
+    })
+
+    await Promise.all(
+        [...new Set(relatedSetupItems.map((item) => item.setupId))].map((setupId) =>
+            purgeSetupCache(setupId),
+        ),
+    )
+
+    await useStorage('cache').del(getLockKey(message.id, message.platform))
+}
+
+export const clearItemRevalidationLock = async (message: ItemRevalidationMessage) => {
+    await useStorage('cache').del(getLockKey(message.id, message.platform))
+}

--- a/server/utils/waitUntil.ts
+++ b/server/utils/waitUntil.ts
@@ -1,11 +1,15 @@
 const waitUntilLog = logger('waitUntil')
 
 export const runAfterResponse = (promise: Promise<unknown>) => {
-    const event = useEvent()
+    try {
+        const event = useEvent()
 
-    if (event.waitUntil) {
-        event.waitUntil(promise)
-        return
+        if (event.waitUntil) {
+            event.waitUntil(promise)
+            return
+        }
+    } catch {
+        // Not running inside an H3 request context, such as a Cloudflare Queue consumer.
     }
 
     void promise.catch((error) => {

--- a/shared/utils/auth.ts
+++ b/shared/utils/auth.ts
@@ -15,7 +15,28 @@ import {
     SESSION_COOKIE_CACHE_MAX_AGE,
 } from './constants'
 
+type CachedUserSettings = {
+    updatedAt: Date | string | null
+    showPrivateSetups: boolean
+    showNSFW: boolean
+} | null
+
 const JPG_FILENAME_LENGTH = 16
+const userSettingsCacheKey = (userId: string) =>
+    `user-settings:${encodeURIComponent(userId)}`
+
+const normalizeCachedUserSettings = (settings: CachedUserSettings) =>
+    settings
+        ? {
+              ...settings,
+              updatedAt: settings.updatedAt ? new Date(settings.updatedAt) : null,
+          }
+        : settings
+
+export const purgeUserSettingsSessionCache = async (userId: string) => {
+    await useStorage('auth').del(userSettingsCacheKey(userId))
+}
+
 const minUsernameLength = 3
 const productionCookies =
     process.env.NODE_ENV === 'production' || process.env.CLOUDFLARE_ENV === 'production'
@@ -185,14 +206,25 @@ export const auth = betterAuth({
     plugins: [
         ...(options.plugins ?? []),
         customSession(async ({ user, session }) => {
-            const settings = await dbProxy.query.userSettings.findFirst({
-                where: { userId: { eq: user.id } },
-                columns: {
-                    updatedAt: true,
-                    showPrivateSetups: true,
-                    showNSFW: true,
-                },
+            const key = userSettingsCacheKey(user.id)
+            const cachedSettings = await useStorage('auth').getItem<CachedUserSettings>(key)
+            const settings = normalizeCachedUserSettings(
+                cachedSettings !== undefined
+                    ? cachedSettings
+                    : ((await dbProxy.query.userSettings.findFirst({
+                          where: { userId: { eq: user.id } },
+                          columns: {
+                              updatedAt: true,
+                              showPrivateSetups: true,
+                              showNSFW: true,
+                          },
+                      })) ?? null),
+            )
+
+            await useStorage('auth').setItem(key, settings, {
+                ttl: SESSION_COOKIE_CACHE_MAX_AGE,
             })
+
             return {
                 user: { ...user, settings },
                 session,


### PR DESCRIPTION
### Motivation

- Reduce synchronous item fetching on read paths and offload stale-item updates to a queued background worker to improve response latency.
- Avoid eager loading of device sessions in the auth composable and fetch them only when the UI needs account switching.
- Improve reliability and performance for maintenance flag checks and session-related user settings by adding small caches and invalidation hooks.
- Make Cloudflare observability and queue configuration configurable and wire a queue consumer for item revalidation.

### Description

- Introduce a Cloudflare queue-backed revalidation flow by adding `server/utils/itemRevalidationQueue.ts` with `enqueueItemRevalidation`, `handleItemRevalidationMessage`, and lock management, and register a consumer plugin in `server/plugins/itemRevalidationQueue.ts` to process queue batches.
- Replace inline item-refresh logic in `server/api/items/owned-avatars.get.ts` and per-item remote fetches in `server/api/setups/[id]/index.get.ts` with calls to `enqueueItemRevalidation` and return immediate cached results. 
- Add a cached helper `getPopularAvatars` (via `defineCachedFunction`) to `server/api/items/popular-avatars.get.ts` to cache popular avatars for a day. 
- Add queue configuration and make Cloudflare observability `head_sampling_rate` driven by `CLOUDFLARE_OBSERVABILITY_HEAD_SAMPLING_RATE` in `nuxt.config.ts`. 
- Gate server session resolution in `server/utils/eventHandler.ts` to only resolve sessions when a `better-auth` cookie is present, and make `getItem` accept an optional `event` to allow background revalidation outside request contexts. 
- Add maintenance-flag caching helpers in `server/utils/appFlags.ts` (`getMaintenanceFlag`, `clearMaintenanceFlagCache`) and switch maintenance middleware to use `getMaintenanceFlag` in `server/middleware/maintenance.ts`. 
- Add `purgeUserSettingsSessionCache` and cache user settings in `shared/utils/auth.ts` so `customSession` uses cached settings and `server/api/users/me/settings.put.ts` purges that cache after updates. 
- Make `runAfterResponse` tolerant when not running inside an H3 request context by catching `useEvent()` errors in `server/utils/waitUntil.ts`. 
- UI changes: in `app/components/header/menu.vue` add a local `open` `ref`, wire `v-model:open` to the dropdown, and lazily call `getSessions()` when the menu opens; and in the auth composable `app/composables/auth.ts` stop awaiting `getSessions()` during initialization so device sessions are loaded lazily. 

### Testing

- Ran the automated unit and integration test suite with `pnpm test`, and the test run completed successfully. 
- Ran linting with `pnpm lint` and formatting checks which passed without changes. 
- Exercised the Cloudflare queue consumer logic in a local/staging environment by enqueueing sample messages and observing successful processing and cache purges.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4884a908832688efed13dc1398c3)