### PR TITLE
Add admin Storage UI and Files API; centralize storage client via `getStorage`

### DIFF
--- a/app/components/filesSdk/fileBrowser.vue
+++ b/app/components/filesSdk/fileBrowser.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import type { StoredFile } from 'files-sdk'
+import type { FilesClient } from 'files-sdk/vue'
+
+const props = defineProps<{
+    files: FilesClient
+    selectedKey?: string
+}>()
+
+const emit = defineEmits<{
+    select: [file: StoredFile]
+}>()
+
+const prefix = ref('')
+const items = ref<StoredFile[]>([])
+const prefixes = ref<string[]>([])
+const cursor = ref<string>()
+const pending = ref(false)
+const errorMessage = ref<string>()
+
+const parentPrefix = computed(() => {
+    if (!prefix.value) return undefined
+    const segments = prefix.value.replace(/\/$/, '').split('/')
+    segments.pop()
+    return segments.length ? `${segments.join('/')}/` : ''
+})
+
+const breadcrumbs = computed(() => {
+    const crumbs = [{ label: 'Root', prefix: '' }]
+    let current = ''
+    for (const segment of prefix.value.split('/').filter(Boolean)) {
+        current += `${segment}/`
+        crumbs.push({ label: segment, prefix: current })
+    }
+    return crumbs
+})
+
+const formatSize = (size: number) =>
+    new Intl.NumberFormat('en', {
+        notation: 'compact',
+        maximumFractionDigits: 1,
+    }).format(size)
+
+const getFolderName = (folderPrefix: string) =>
+    folderPrefix.slice(0, -1).split('/').at(-1) || folderPrefix
+
+const load = async (nextCursor?: string) => {
+    pending.value = true
+    errorMessage.value = undefined
+
+    try {
+        const result = await props.files.list({
+            prefix: prefix.value || undefined,
+            cursor: nextCursor,
+            delimiter: '/',
+            limit: 100,
+        })
+
+        if (nextCursor) {
+            items.value = [...items.value, ...result.items]
+            prefixes.value = [...prefixes.value, ...(result.prefixes ?? [])]
+        } else {
+            items.value = result.items
+            prefixes.value = result.prefixes ?? []
+        }
+        cursor.value = result.cursor
+    } catch (error) {
+        errorMessage.value = error instanceof Error ? error.message : 'Failed to load files.'
+    } finally {
+        pending.value = false
+    }
+}
+
+const openPrefix = async (nextPrefix: string) => {
+    prefix.value = nextPrefix
+    await load()
+}
+
+const refresh = async () => await load()
+
+watch(
+    () => props.files,
+    () => {
+        void load()
+    },
+    { immediate: true },
+)
+</script>
+
+<template>
+    <UPageCard
+        variant="subtle"
+        :ui="{
+            root: 'min-h-0 grow',
+            container: 'h-full min-h-0 gap-2 p-0 sm:p-0',
+            body: 'flex min-h-0 flex-col p-0 sm:p-0',
+        }"
+        class="overflow-hidden rounded-lg"
+    >
+        <template #header>
+            <div class="flex items-center gap-2 p-3">
+                <UButton
+                    icon="mingcute:arrow-up-line"
+                    variant="ghost"
+                    color="neutral"
+                    size="sm"
+                    :disabled="parentPrefix === undefined"
+                    @click="
+                        () => {
+                            if (parentPrefix !== undefined) void openPrefix(parentPrefix)
+                        }
+                    "
+                />
+                <UBreadcrumb
+                    :items="
+                        breadcrumbs.map((crumb) => ({
+                            label: crumb.label,
+                            onSelect: () => openPrefix(crumb.prefix),
+                        }))
+                    "
+                    class="min-w-0 flex-1"
+                />
+                <UButton
+                    icon="mingcute:refresh-2-line"
+                    variant="ghost"
+                    color="neutral"
+                    size="sm"
+                    :loading="pending"
+                    @click="refresh"
+                />
+            </div>
+        </template>
+
+        <template #body>
+            <UAlert
+                v-if="errorMessage"
+                color="error"
+                variant="soft"
+                icon="mingcute:warning-fill"
+                :description="errorMessage"
+                class="m-3"
+            />
+
+            <div v-else class="min-h-0 flex-1 overflow-auto">
+                <div
+                    v-if="!pending && !prefixes.length && !items.length"
+                    class="text-muted flex h-full items-center justify-center text-sm"
+                >
+                    No files found.
+                </div>
+
+                <div v-else class="divide-default divide-y">
+                    <button
+                        v-for="folder in prefixes"
+                        :key="folder"
+                        type="button"
+                        class="hover:bg-elevated/60 flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition"
+                        @click="openPrefix(folder)"
+                    >
+                        <Icon name="mingcute:folder-fill" class="text-warning size-5 shrink-0" />
+                        <span class="text-highlighted min-w-0 flex-1 truncate font-medium">
+                            {{ getFolderName(folder) }}
+                        </span>
+                        <span class="text-muted text-xs">Folder</span>
+                    </button>
+
+                    <button
+                        v-for="file in items"
+                        :key="file.key"
+                        type="button"
+                        class="hover:bg-elevated/60 flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition"
+                        :class="file.key === selectedKey && 'bg-primary/10'"
+                        @click="emit('select', file)"
+                    >
+                        <Icon name="mingcute:file-fill" class="text-muted size-5 shrink-0" />
+                        <div class="min-w-0 flex-1">
+                            <p class="text-highlighted truncate font-medium">{{ file.name }}</p>
+                            <p class="text-muted truncate font-mono text-[11px]">{{ file.key }}</p>
+                        </div>
+                        <span class="text-muted font-mono text-xs">{{
+                            formatSize(file.size)
+                        }}</span>
+                    </button>
+                </div>
+
+                <div v-if="cursor" class="p-3">
+                    <UButton
+                        block
+                        variant="soft"
+                        color="neutral"
+                        :loading="pending"
+                        @click="load(cursor)"
+                    >
+                        Load more
+                    </UButton>
+                </div>
+            </div>
+        </template>
+    </UPageCard>
+</template>

--- a/app/components/filesSdk/filePreview.vue
+++ b/app/components/filesSdk/filePreview.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import type { StoredFile } from 'files-sdk'
+import type { FilesClient } from 'files-sdk/vue'
+
+const props = defineProps<{
+    files: FilesClient
+    file?: StoredFile
+}>()
+
+const objectUrl = ref<string>()
+const publicUrl = ref<string>()
+const textPreview = ref<string>()
+const pending = ref(false)
+const errorMessage = ref<string>()
+
+const isImage = computed(() => props.file?.type.startsWith('image/'))
+const isText = computed(() => {
+    const type = props.file?.type ?? ''
+    return type.startsWith('text/') || type.includes('json') || type.includes('xml')
+})
+
+const fileDate = computed(() =>
+    props.file?.lastModified ? new Date(props.file.lastModified).toLocaleString('en') : 'Unknown',
+)
+
+const fileSize = computed(() =>
+    props.file
+        ? new Intl.NumberFormat('en', {
+              notation: 'compact',
+              maximumFractionDigits: 1,
+          }).format(props.file.size)
+        : '',
+)
+
+const clearObjectUrl = () => {
+    if (objectUrl.value) URL.revokeObjectURL(objectUrl.value)
+    objectUrl.value = undefined
+}
+
+const loadPreview = async () => {
+    clearObjectUrl()
+    publicUrl.value = undefined
+    textPreview.value = undefined
+    errorMessage.value = undefined
+
+    if (!props.file) return
+
+    pending.value = true
+    try {
+        publicUrl.value = await props.files.url(props.file.key)
+
+        if (isImage.value) objectUrl.value = publicUrl.value
+        else if (isText.value && props.file.size <= 128 * 1024) {
+            const downloaded = await props.files.download(props.file.key, { as: 'blob' })
+            textPreview.value = await downloaded.text()
+        }
+    } catch (error) {
+        errorMessage.value = error instanceof Error ? error.message : 'Failed to preview file.'
+    } finally {
+        pending.value = false
+    }
+}
+
+watch(
+    () => props.file?.key,
+    () => {
+        void loadPreview()
+    },
+    { immediate: true },
+)
+
+onBeforeUnmount(clearObjectUrl)
+</script>
+
+<template>
+    <UPageCard
+        variant="subtle"
+        :ui="{ root: 'h-full min-h-0', container: 'h-full min-h-0 gap-3', body: 'min-h-0' }"
+        class="rounded-lg"
+    >
+        <template #title>File Preview</template>
+
+        <div v-if="!file" class="text-muted flex h-full items-center justify-center text-sm">
+            Select a file to preview.
+        </div>
+
+        <div v-else class="flex h-full min-h-0 flex-col gap-3">
+            <div class="flex items-start gap-3">
+                <Icon name="mingcute:file-fill" class="text-muted mt-1 size-5 shrink-0" />
+                <div class="min-w-0 flex-1">
+                    <h2 class="text-highlighted truncate font-medium">{{ file.name }}</h2>
+                    <p class="text-muted font-mono text-xs break-all">{{ file.key }}</p>
+                </div>
+            </div>
+
+            <UAlert
+                v-if="errorMessage"
+                color="error"
+                variant="soft"
+                icon="mingcute:warning-fill"
+                :description="errorMessage"
+            />
+
+            <div
+                class="bg-default/70 border-default flex min-h-52 items-center justify-center overflow-hidden rounded-lg border"
+            >
+                <img
+                    v-if="isImage && objectUrl"
+                    :src="objectUrl"
+                    :alt="file.name"
+                    class="max-h-96 max-w-full object-contain"
+                />
+                <pre
+                    v-else-if="textPreview"
+                    class="size-full max-h-96 overflow-auto p-3 text-xs whitespace-pre-wrap"
+                    >{{ textPreview }}</pre
+                >
+                <div v-else class="text-muted flex flex-col items-center gap-2 text-sm">
+                    <Icon
+                        :name="
+                            pending ? 'svg-spinners:180-ring-with-bg' : 'mingcute:file-unknown-fill'
+                        "
+                        class="size-8"
+                    />
+                    <span>{{ pending ? 'Loading preview...' : 'Preview is not available.' }}</span>
+                </div>
+            </div>
+
+            <dl class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-xs">
+                <dt class="text-muted">Type</dt>
+                <dd class="text-highlighted min-w-0 truncate font-mono">
+                    {{ file.type || 'Unknown' }}
+                </dd>
+                <dt class="text-muted">Size</dt>
+                <dd class="text-highlighted font-mono">{{ fileSize }}</dd>
+                <dt class="text-muted">Updated</dt>
+                <dd class="text-highlighted font-mono">{{ fileDate }}</dd>
+                <dt v-if="file.etag" class="text-muted">ETag</dt>
+                <dd v-if="file.etag" class="text-highlighted min-w-0 truncate font-mono">
+                    {{ file.etag }}
+                </dd>
+            </dl>
+
+            <div class="mt-auto flex gap-2">
+                <UButton
+                    v-if="publicUrl"
+                    :to="publicUrl"
+                    target="_blank"
+                    external
+                    icon="mingcute:external-link-line"
+                    label="Open"
+                    variant="soft"
+                    color="neutral"
+                    size="sm"
+                />
+                <UButton
+                    v-if="publicUrl"
+                    :to="publicUrl"
+                    download
+                    external
+                    icon="mingcute:download-line"
+                    label="Download"
+                    variant="ghost"
+                    color="neutral"
+                    size="sm"
+                />
+            </div>
+        </div>
+    </UPageCard>
+</template>

--- a/app/components/filesSdk/fileSearch.vue
+++ b/app/components/filesSdk/fileSearch.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import type { SearchMatch, StoredFile } from 'files-sdk'
+import type { FilesClient } from 'files-sdk/vue'
+
+const props = defineProps<{
+    files: FilesClient
+    selectedKey?: string
+}>()
+
+const emit = defineEmits<{
+    select: [file: StoredFile]
+}>()
+
+const query = ref('')
+const match = ref<SearchMatch>('substring')
+const caseInsensitive = ref(true)
+const results = ref<StoredFile[]>([])
+const pending = ref(false)
+const errorMessage = ref<string>()
+
+const matchItems = [
+    { label: 'Substring', value: 'substring' },
+    { label: 'Glob', value: 'glob' },
+    { label: 'Regex', value: 'regex' },
+    { label: 'Exact', value: 'exact' },
+] satisfies { label: string; value: SearchMatch }[]
+
+const formatSize = (size: number) =>
+    new Intl.NumberFormat('en', {
+        notation: 'compact',
+        maximumFractionDigits: 1,
+    }).format(size)
+
+const search = async () => {
+    const pattern = query.value.trim()
+    if (!pattern) {
+        results.value = []
+        errorMessage.value = undefined
+        return
+    }
+
+    pending.value = true
+    errorMessage.value = undefined
+
+    try {
+        const nextResults: StoredFile[] = []
+        for await (const file of props.files.search(pattern, {
+            match: match.value,
+            caseInsensitive: caseInsensitive.value,
+            maxResults: 50,
+            limit: 100,
+        }))
+            nextResults.push(file)
+        results.value = nextResults
+    } catch (error) {
+        errorMessage.value = error instanceof Error ? error.message : 'Failed to search files.'
+    } finally {
+        pending.value = false
+    }
+}
+
+const debouncedSearch = useDebounceFn(search, 300)
+
+watch([query, match, caseInsensitive], () => {
+    void debouncedSearch()
+})
+</script>
+
+<template>
+    <UPageCard variant="subtle" :ui="{ container: 'gap-2 p-3 sm:p-3' }" class="rounded-lg">
+        <div class="flex flex-wrap items-center gap-2">
+            <UInput
+                v-model="query"
+                icon="mingcute:search-line"
+                placeholder="Search files..."
+                variant="soft"
+                size="sm"
+                class="min-w-56 flex-1 rounded-lg"
+                @keydown.enter="search"
+            />
+            <USelect
+                v-model="match"
+                :items="matchItems"
+                value-key="value"
+                label-key="label"
+                size="sm"
+                class="w-32 rounded-lg"
+            />
+            <UCheckbox v-model="caseInsensitive" label="Ignore case" size="sm" />
+            <UButton
+                icon="mingcute:search-line"
+                variant="soft"
+                color="neutral"
+                size="sm"
+                :loading="pending"
+                @click="search"
+            />
+        </div>
+
+        <UAlert
+            v-if="errorMessage"
+            color="error"
+            variant="soft"
+            icon="mingcute:warning-fill"
+            :description="errorMessage"
+        />
+
+        <div v-if="results.length" class="border-default max-h-52 overflow-auto rounded-md border">
+            <button
+                v-for="file in results"
+                :key="file.key"
+                type="button"
+                class="hover:bg-elevated/60 border-default flex w-full items-center gap-3 border-b px-3 py-2 text-left text-xs last:border-b-0"
+                :class="file.key === selectedKey && 'bg-primary/10'"
+                @click="emit('select', file)"
+            >
+                <Icon name="mingcute:file-search-fill" class="text-muted size-4 shrink-0" />
+                <span class="text-highlighted min-w-0 flex-1 truncate font-mono">
+                    {{ file.key }}
+                </span>
+                <span class="text-muted font-mono">{{ formatSize(file.size) }}</span>
+            </button>
+        </div>
+    </UPageCard>
+</template>

--- a/app/layouts/dashboard.vue
+++ b/app/layouts/dashboard.vue
@@ -106,6 +106,11 @@ const dev = import.meta.dev
                                 icon: 'mingcute:mail-fill',
                                 to: '/admin/emails',
                             },
+                            {
+                                label: 'Storage',
+                                icon: 'mingcute:folder-fill',
+                                to: '/admin/storage',
+                            },
                         ]"
                         orientation="vertical"
                         tooltip

--- a/app/pages/admin/storage.vue
+++ b/app/pages/admin/storage.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { StoredFile } from 'files-sdk'
+import { useFiles } from 'files-sdk/vue'
+
+const files = useFiles({ endpoint: '/api/admin/files' })
+const selectedFile = ref<StoredFile>()
+
+const selectFile = (file: StoredFile) => {
+    selectedFile.value = file
+}
+
+useSeo({
+    title: 'Admin - Storage',
+})
+</script>
+
+<template>
+    <UDashboardPanel id="storage" :ui="{ body: 'p-0 sm:p-0 min-h-0' }" class="max-w-[100qw]">
+        <template #header>
+            <UDashboardNavbar title="Storage" />
+        </template>
+
+        <template #body>
+            <div class="grid min-h-0 grow gap-2 p-2 lg:grid-cols-[minmax(0,1fr)_24rem]">
+                <div class="flex min-h-0 flex-col gap-2">
+                    <FilesSdkFileSearch
+                        :files="files"
+                        :selected-key="selectedFile?.key"
+                        @select="selectFile"
+                    />
+                    <FilesSdkFileBrowser
+                        :files="files"
+                        :selected-key="selectedFile?.key"
+                        @select="selectFile"
+                    />
+                </div>
+
+                <FilesSdkFilePreview :files="files" :file="selectedFile" class="min-h-96" />
+            </div>
+        </template>
+    </UDashboardPanel>
+</template>

--- a/app/utils/uploadImage.ts
+++ b/app/utils/uploadImage.ts
@@ -42,7 +42,7 @@ export const uploadImage = async (file: File, path: 'setup' | 'avatar'): Promise
             headers?: Record<string, string>
             fields?: Record<string, string>
             expiresAt: string
-        }>('/api/images/upload-url', {
+        }>('/api/files/upload-url', {
             method: 'POST',
             body: {
                 path,
@@ -67,7 +67,7 @@ export const uploadImage = async (file: File, path: 'setup' | 'avatar'): Promise
 
     if (!uploadResponse.ok) throw new Error('Failed to upload image.')
 
-    return await $fetch<UploadedImage>('/api/images/complete', {
+    return await $fetch<UploadedImage>('/api/files/complete', {
         method: 'POST',
         body: {
             objectKey: upload.objectKey,

--- a/server/api/admin/files.ts
+++ b/server/api/admin/files.ts
@@ -1,0 +1,50 @@
+import { createFilesRouter, type FilesOperation } from 'files-sdk/api'
+import { createRouteHandler } from 'files-sdk/nitro'
+
+const allowedOperations = [
+    'head',
+    'exists',
+    'list',
+    'search',
+    'url',
+    'capabilities',
+    'download',
+    'upload',
+    'delete',
+    'copy',
+    'move',
+    'signedUploadUrl',
+] as const satisfies readonly FilesOperation[]
+
+const normalizeOrigin = (origin: string) => origin.replace(/\/$/, '')
+
+const isAllowedOrigin = (origin: string) => {
+    const normalizedOrigin = normalizeOrigin(origin)
+    const siteUrl = getRuntimeEnvString('PUBLIC_SITE_URL')
+
+    return (
+        (siteUrl && normalizedOrigin === normalizeOrigin(siteUrl)) ||
+        (import.meta.dev && normalizedOrigin === 'http://localhost:3000')
+    )
+}
+
+const router = createFilesRouter({
+    files: () => getStorage(),
+    operations: allowedOperations,
+    allowedOrigins: isAllowedOrigin,
+    maxListLimit: 500,
+    maxSearchResults: 500,
+    maxUploadSize: MAX_IMAGE_UPLOAD_SIZE,
+    authorize: async ({ req, operation }) => {
+        const session = await auth.api.getSession({ headers: req.headers })
+        assertAdminSession(session)
+
+        const disposition = operation === 'url' || operation === 'download' ? 'inline' : undefined
+        return {
+            disposition,
+            maxResults: 500,
+        }
+    },
+})
+
+export default defineEventHandler(createRouteHandler(router))

--- a/server/api/files/complete.post.ts
+++ b/server/api/files/complete.post.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid'
 import { withHttps } from 'ufo'
 import { z } from 'zod'
 
-const log = logger('/api/images/complete:POST')
+const log = logger('/api/files/complete:POST')
 
 type ImageUploadPath = (typeof IMAGE_UPLOAD_PATHS)[number]
 type ImageContentType = (typeof IMAGE_CONTENT_TYPES)[number]
@@ -58,25 +58,29 @@ export default authedSessionEventHandler(
         const contentType = head.type ?? head.contentType ?? ''
 
         if (!isImageContentType(contentType)) {
-            await storage.delete(objectKey).catch(() => null)
+            await getStorage()
+                .delete(objectKey)
+                .catch(() => null)
             await invalidateStorageHeadCache(objectKey)
             throw serverError.badRequest({ responseMessage: 'Unsupported image type.' })
         }
 
         if (!head.size || head.size > MAX_IMAGE_UPLOAD_SIZE) {
-            await storage.delete(objectKey).catch(() => null)
+            await getStorage()
+                .delete(objectKey)
+                .catch(() => null)
             await invalidateStorageHeadCache(objectKey)
             throw serverError.badRequest({ responseMessage: 'Image is too large.' })
         }
 
         const finalKey = createImageKey(path, session.user.id, contentType)
-        await storage.move(objectKey, finalKey)
+        await getStorage().move(objectKey, finalKey)
         await Promise.all([
             invalidateStorageHeadCache(objectKey),
             invalidateStorageHeadCache(finalKey),
         ])
 
-        const url = withHttps(await storage.url(finalKey))
+        const url = withHttps(await getStorage().url(finalKey))
         const { colors } = await extractImageColors(url)
 
         await createAuditLog(db, {

--- a/server/api/files/index.post.ts
+++ b/server/api/files/index.post.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid'
 import { withHttps } from 'ufo'
 import { z } from 'zod'
 
-const log = logger('/api/images:POST')
+const log = logger('/api/files:POST')
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024 // クライアント圧縮後の上限（2MB）
 const JPG_FILENAME_LENGTH = 16 // JPEGファイル名の長さ
@@ -48,7 +48,7 @@ export default authedSessionEventHandler(
         const objectKey = `${path}/${session.user.id}/${jpgFilename}`
 
         try {
-            await storage.upload(objectKey, blob, { contentType: 'image/jpeg' })
+            await getStorage().upload(objectKey, blob, { contentType: 'image/jpeg' })
         } catch {
             throw serverError.internalServerError()
         }
@@ -56,7 +56,7 @@ export default authedSessionEventHandler(
         log.success('Image processed and uploaded successfully:', objectKey)
         return {
             objectKey,
-            url: withHttps(await storage.url(objectKey)),
+            url: withHttps(await getStorage().url(objectKey)),
             width,
             height,
             themeColors,

--- a/server/api/files/upload-url.post.ts
+++ b/server/api/files/upload-url.post.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
 
-const log = logger('/api/images/upload-url:POST')
+const log = logger('/api/files/upload-url:POST')
 const SIGNED_UPLOAD_EXPIRES_IN = 60 * 5
 
 type ImageUploadPath = (typeof IMAGE_UPLOAD_PATHS)[number]
@@ -36,7 +36,7 @@ export default authedSessionEventHandler(
 
         const objectKey = createTemporaryImageKey(path, session.user.id, contentType)
 
-        const signed = await storage.signedUploadUrl(objectKey, {
+        const signed = await getStorage().signedUploadUrl(objectKey, {
             contentType,
             expiresIn: SIGNED_UPLOAD_EXPIRES_IN,
             maxSize: MAX_IMAGE_UPLOAD_SIZE,

--- a/server/utils/adminAuth.ts
+++ b/server/utils/adminAuth.ts
@@ -1,0 +1,8 @@
+export const isAdminSession = (session: Session | null): session is NonNullable<Session> =>
+    session?.user.role === 'admin'
+
+export const assertAdminSession = (
+    session: Session | null,
+): asserts session is NonNullable<Session> => {
+    if (!isAdminSession(session)) throw serverError.forbidden()
+}

--- a/server/utils/adminJobs.ts
+++ b/server/utils/adminJobs.ts
@@ -92,7 +92,7 @@ const getStorageObjects = async (prefix: string): Promise<ImageInfo[]> => {
     const items: ImageInfo[] = []
 
     try {
-        for await (const obj of storage.listAll({ prefix: `${prefix}/` }))
+        for await (const obj of getStorage().listAll({ prefix: `${prefix}/` }))
             items.push({
                 key: obj.key,
                 lastModified: new Date(obj.lastModified ?? Date.now()),
@@ -124,7 +124,10 @@ const copyWithConcurrency = async (images: ImageInfo[], backupDate: string) => {
                 if (!image) return
 
                 try {
-                    await storage.copy(image.key, `${BACKUP_PREFIX}/${backupDate}/${image.key}`)
+                    await getStorage().copy(
+                        image.key,
+                        `${BACKUP_PREFIX}/${backupDate}/${image.key}`,
+                    )
                     backedUp.push(image.key)
                 } catch (error) {
                     cleanupLog.warn('Failed to backup image before deletion:', image.key, error)
@@ -436,7 +439,7 @@ export const runCleanupJob = async ({ dryRun = false }: CleanupJobOptions = {}) 
 
     const deleteResults =
         imagesToDelete.length > 0
-            ? await storage.delete(
+            ? await getStorage().delete(
                   imagesToDelete.map((image) => image.key),
                   { concurrency: STORAGE_OPERATION_CONCURRENCY },
               )

--- a/server/utils/eventHandler.ts
+++ b/server/utils/eventHandler.ts
@@ -75,7 +75,7 @@ export const adminSessionEventHandler = <T = unknown>(
     options?: SessionEventHandlerOptions,
 ) =>
     sessionEventHandler(async ({ event, session, db }) => {
-        if (!session || session.user.role !== 'admin') throw serverError.forbidden()
+        assertAdminSession(session)
 
         return await handler({ event, session, db })
     }, options)

--- a/server/utils/setupImages.ts
+++ b/server/utils/setupImages.ts
@@ -3,7 +3,7 @@ import type { SetupImageMetadata } from '@@/shared/types/database'
 import { and, eq, inArray } from 'drizzle-orm'
 import { withHttps } from 'ufo'
 
-import { storage } from './storage'
+import { getStorage } from './storage'
 
 interface ResolveSetupImageDataOptions {
     userId: string
@@ -18,7 +18,7 @@ export const withSetupImageUrls = async <T extends { objectKey: string }>(
     await Promise.all(
         images.map(async (image) => ({
             ...image,
-            url: withHttps(await storage.url(image.objectKey)),
+            url: withHttps(await getStorage().url(image.objectKey)),
         })),
     )
 

--- a/server/utils/storage.ts
+++ b/server/utils/storage.ts
@@ -19,7 +19,7 @@ const requireEnv = (name: string) => {
 
 let storageClient: StorageClient | null = null
 
-const getStorage = () => {
+export const getStorage = () => {
     if (storageClient) return storageClient
 
     const binding = getRuntimeEnv().R2 as R2Bucket | undefined
@@ -42,14 +42,6 @@ const getStorage = () => {
     return storageClient
 }
 
-export const storage = new Proxy({} as StorageClient, {
-    get: (_target, property) => {
-        const client = getStorage()
-        const value = Reflect.get(client, property)
-        return typeof value === 'function' ? value.bind(client) : value
-    },
-})
-
 const fileCache = () => useStorage('cache')
 const fileCacheKey = (type: 'head', key: string) => `files:${type}:${key}`
 
@@ -61,7 +53,7 @@ export const cachedStorageHead = async (key: string): Promise<StoredFile> => {
     const cached = await fileCache().getItem<StoredFile>(cacheKey)
     if (cached) return cached
 
-    const head = await storage.head(key)
+    const head = await getStorage().head(key)
     await fileCache().setItem(cacheKey, head)
     return head
 }

--- a/shared/utils/auth.ts
+++ b/shared/utils/auth.ts
@@ -7,7 +7,7 @@ import { useStorage } from 'nitropack/runtime/internal/storage'
 import { withHttps } from 'ufo'
 
 import { dbProxy, schema } from '../../server/utils/database'
-import { storage } from '../../server/utils/storage'
+import { getStorage } from '../../server/utils/storage'
 import {
     RATE_LIMIT_DEFAULT,
     RATE_LIMIT_SESSION,
@@ -159,14 +159,14 @@ const options = {
                             const buffer = await $fetch<Blob>(image)
                             const arrayBuffer = await buffer.arrayBuffer()
                             const imageId = nanoid(JPG_FILENAME_LENGTH)
-                            await storage.upload(
+                            await getStorage().upload(
                                 `avatar/${imageId}.jpg`,
                                 Buffer.from(arrayBuffer),
                                 {
                                     contentType: 'image/jpeg',
                                 },
                             )
-                            image = withHttps(await storage.url(`avatar/${imageId}.jpg`))
+                            image = withHttps(await getStorage().url(`avatar/${imageId}.jpg`))
                         } catch {
                             image = null
                         }


### PR DESCRIPTION
### Motivation

- Provide an administrative UI to browse, search, and preview stored files and expose a secure server-side API for file operations using the `files-sdk`.
- Centralize access to the R2/Files client to ensure consistent usage across server modules and simplify switching between binding and direct credentials.
- Replace image-specific upload endpoints with more generic file endpoints to support broader file operations in the admin UI.

### Description

- Added three new Vue components `FilesSdkFileBrowser`, `FilesSdkFilePreview`, and `FilesSdkFileSearch` under `app/components/filesSdk/` to browse, preview, and search storage objects using the `files-sdk` client.
- Introduced the admin storage page at `app/pages/admin/storage.vue` and a navigation item in the dashboard layout to access the new storage UI.
- Implemented a server-side admin files router at `server/api/admin/files.ts` using `createFilesRouter` from `files-sdk/api` with allowed operations and admin authorization via `assertAdminSession`.
- Centralized the storage client by exporting `getStorage` from `server/utils/storage.ts` and replaced previous `storage` proxy usage with `getStorage()` calls across server utilities and API handlers.
- Renamed and migrated image-specific endpoints to file-oriented routes under `server/api/files/*` (`upload-url`, `index`, `complete`) and updated `app/utils/uploadImage.ts` to use the new endpoints.
- Added admin helper utilities in `server/utils/adminAuth.ts` and updated `server/utils/eventHandler.ts` to use `assertAdminSession` via the new admin event handler wrapper.

### Testing

- Ran TypeScript type checking with `npm run typecheck` which completed without errors.
- Executed linting via `npm run lint` and fixed issues introduced by the changes, resulting in a clean lint pass.
- Ran the project's automated test suite (`npm test`) and the relevant server API and utility unit tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45b7f2bf488326b31bb7f9b52f2b2c)