### PR TITLE
fix: return 404 for missing content pages

### DIFF
--- a/app/pages/[slug].vue
+++ b/app/pages/[slug].vue
@@ -19,7 +19,7 @@ const slug = computed(() =>
 
 const { data } = await useContentPage(slug.value)
 
-if (!data.value) throw createError({ statusCode: 404, statusMessage: 'Page not found.' })
+if (!data.value?.content) throw createError({ statusCode: 404, statusMessage: 'Page not found.' })
 
 const commitLogUrl = computed(() => {
     if (!data.value?.content?.commitLogPath) return null

--- a/test/nuxt/contentPage.spec.ts
+++ b/test/nuxt/contentPage.spec.ts
@@ -1,0 +1,27 @@
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+
+import ContentPage from '~/pages/[slug].vue'
+
+const { ogImageMock } = vi.hoisted(() => ({ ogImageMock: vi.fn() }))
+
+mockNuxtImport('useRoute', () => () => ({
+    fullPath: '/missing',
+    matched: [],
+    meta: {},
+    params: { slug: 'missing' },
+    path: '/missing',
+    query: {},
+}))
+mockNuxtImport(
+    'useContentPage',
+    () => () => Promise.resolve({ data: ref({ content: null, isFallback: false }) }),
+)
+mockNuxtImport('useOgImage', () => ogImageMock)
+
+describe('content page', () => {
+    it('throws before generating an OG image when content is missing', async () => {
+        await expect(mountSuspended(ContentPage)).rejects.toMatchObject({ statusCode: 404 })
+        expect(ogImageMock).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary

- treat `useContentPage()` results with `content: null` as missing
- throw 404 before OG image generation
- add a Nuxt regression test proving missing content does not call `useOgImage`

## Why

Production smoke testing after #301 showed unknown GET paths still returned an empty 200 page. The composable returns an object even when its nested `content` is null, so the previous guard did not fire.

## Validation

- `bun run test:nuxt` — 3 files / 7 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run fmt:check`
- `bun run build`
- `bun run cf:check`