### PR TITLE
fix(auth): restore session user relation

### DIFF
--- a/database/relations.ts
+++ b/database/relations.ts
@@ -4,6 +4,10 @@ import * as schema from './schema'
 
 export const relations = defineRelations(schema, (r) => ({
     users: {
+        sessions: r.many.sessions({
+            from: r.users.id,
+            to: r.sessions.userId,
+        }),
         accounts: r.many.accounts({
             from: r.users.id,
             to: r.accounts.userId,
@@ -71,6 +75,13 @@ export const relations = defineRelations(schema, (r) => ({
         followers: r.many.followUsers({
             from: r.users.id,
             to: r.followUsers.targetUserId,
+        }),
+    },
+    sessions: {
+        user: r.one.users({
+            from: r.sessions.userId,
+            to: r.users.id,
+            optional: false,
         }),
     },
     accounts: {

--- a/test/unit/server/authRelations.spec.ts
+++ b/test/unit/server/authRelations.spec.ts
@@ -1,0 +1,20 @@
+import { drizzle } from 'drizzle-orm/neon-serverless'
+import { describe, expect, it } from 'vitest'
+
+import { relations } from '../../../database/relations'
+
+describe('Better Auth relations', () => {
+    it('builds the session query with its joined user', () => {
+        const db = drizzle.mock({ relations })
+
+        const query = db.query.sessions
+            .findFirst({
+                where: { token: { eq: 'session-token' } },
+                with: { user: true },
+            })
+            .toSQL()
+
+        expect(query.sql).toContain('"user"."sessions"')
+        expect(query.sql).toContain('"user"."users"')
+    })
+})


### PR DESCRIPTION
Restores the missing Drizzle relations between Better Auth sessions and users so joined session lookup no longer throws while reading relation.targetTable. Adds a regression test that builds the exact session-with-user query. Validated with typecheck, lint, formatting, all unit and Nuxt tests, production build, and Wrangler dry-run.