### PR TITLE
fix(auth): map OAuth account identifier

### DIFF
--- a/server/utils/authSchemaOptions.ts
+++ b/server/utils/authSchemaOptions.ts
@@ -4,6 +4,12 @@ import { admin, multiSession, username } from 'better-auth/plugins'
 const minUsernameLength = 3
 
 export const authSchemaOptions = {
+    account: {
+        fields: {
+            accountId: 'providerAccountId',
+        },
+    },
+
     user: {
         additionalFields: {
             bio: {

--- a/test/unit/server/authAccountSchema.spec.ts
+++ b/test/unit/server/authAccountSchema.spec.ts
@@ -1,0 +1,29 @@
+import { drizzleAdapter } from '@better-auth/drizzle-adapter/relations-v2'
+import { describe, expect, it, vi } from 'vitest'
+
+import * as schema from '../../../database/schema'
+import { authSchemaOptions } from '../../../server/utils/authSchemaOptions'
+
+describe('Better Auth account schema', () => {
+    it('maps the OAuth account ID to the provider account column', async () => {
+        const where = vi.fn().mockResolvedValue([])
+        const from = vi.fn(() => ({ where }))
+        const select = vi.fn(() => ({ from }))
+        const adapter = drizzleAdapter({ select } as never, {
+            provider: 'pg',
+            schema,
+            usePlural: true,
+        })(authSchemaOptions)
+
+        await expect(
+            adapter.findOne({
+                model: 'account',
+                where: [
+                    { field: 'issuer', value: 'https://api.twitter.com' },
+                    { field: 'accountId', value: 'twitter-user' },
+                ],
+            }),
+        ).resolves.toBeNull()
+        expect(select).toHaveBeenCalledOnce()
+    })
+})


### PR DESCRIPTION
Maps Better Auth's internal accountId field to the existing Drizzle providerAccountId column. This fixes Twitter callback account lookup without changing the database schema or data. Adds a regression test for the issuer + accountId adapter query. Verified against the actual Neon schema, plus typecheck, lint, formatting, all unit and Nuxt tests, production build, and Wrangler dry-run.