### PR TITLE
fix(auth): disable broken RC joins

### DIFF
--- a/auth.config.ts
+++ b/auth.config.ts
@@ -13,6 +13,7 @@ export const auth = betterAuth({
     database: drizzleAdapter(database, {
         provider: 'pg',
         schema,
+        schemaName: 'user',
         usePlural: true,
     }),
 })

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -50,6 +50,7 @@ const options = {
     database: drizzleAdapter(dbProxy, {
         provider: 'pg',
         schema,
+        schemaName: 'user',
         usePlural: true,
     }),
 
@@ -176,9 +177,7 @@ const options = {
     },
 
     advanced: {
-        database: {
-            joins: true,
-        },
+        ...authSchemaOptions.advanced,
         ipAddress: {
             ipAddressHeaders: ['x-forwarded-for', 'x-real-ip', 'cf-connecting-ip'],
         },

--- a/server/utils/authSchemaOptions.ts
+++ b/server/utils/authSchemaOptions.ts
@@ -4,6 +4,13 @@ import { admin, multiSession, username } from 'better-auth/plugins'
 const minUsernameLength = 3
 
 export const authSchemaOptions = {
+    advanced: {
+        database: {
+            // ponytail: RC.4 crashes on plural one-to-one joins; re-enable after better-auth#10631 ships.
+            joins: false,
+        },
+    },
+
     account: {
         fields: {
             accountId: 'providerAccountId',

--- a/test/unit/server/authAccountSchema.spec.ts
+++ b/test/unit/server/authAccountSchema.spec.ts
@@ -12,6 +12,7 @@ describe('Better Auth account schema', () => {
         const adapter = drizzleAdapter({ select } as never, {
             provider: 'pg',
             schema,
+            schemaName: 'user',
             usePlural: true,
         })(authSchemaOptions)
 

--- a/test/unit/server/authRelations.spec.ts
+++ b/test/unit/server/authRelations.spec.ts
@@ -1,20 +1,56 @@
+import { drizzleAdapter } from '@better-auth/drizzle-adapter/relations-v2'
 import { drizzle } from 'drizzle-orm/neon-serverless'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { relations } from '../../../database/relations'
+import * as schema from '../../../database/schema'
+import { authSchemaOptions } from '../../../server/utils/authSchemaOptions'
 
 describe('Better Auth relations', () => {
-    it('builds the session query with its joined user', () => {
+    it('falls back to separate session and user queries on RC.4', async () => {
         const db = drizzle.mock({ relations })
+        const rows = new Map([
+            [
+                schema.sessions,
+                [
+                    {
+                        id: 'session-id',
+                        token: 'session-token',
+                        userId: 'user-id',
+                    },
+                ],
+            ],
+            [
+                schema.users,
+                [
+                    {
+                        id: 'user-id',
+                        name: 'User',
+                        email: 'user@example.com',
+                    },
+                ],
+            ],
+        ])
+        const select = vi.fn(() => ({
+            from: (table: typeof schema.sessions | typeof schema.users) => ({
+                where: async () => rows.get(table) ?? [],
+            }),
+        }))
+        db.select = select as typeof db.select
+        const adapter = drizzleAdapter(db, {
+            provider: 'pg',
+            schema,
+            schemaName: 'user',
+            usePlural: true,
+        })(authSchemaOptions)
 
-        const query = db.query.sessions
-            .findFirst({
-                where: { token: { eq: 'session-token' } },
-                with: { user: true },
-            })
-            .toSQL()
+        const session = await adapter.findOne({
+            model: 'session',
+            where: [{ field: 'token', value: 'session-token' }],
+            join: { user: true },
+        })
 
-        expect(query.sql).toContain('"user"."sessions"')
-        expect(query.sql).toContain('"user"."users"')
+        expect(session?.user).toMatchObject({ id: 'user-id' })
+        expect(select).toHaveBeenCalledTimes(2)
     })
 })


### PR DESCRIPTION
## Summary
- disable Better Auth RC.4 relation joins that crash with usePlural and relations-v2
- use the supported separate-query fallback for session/user loading
- align the adapter with the user schema namespace
- cover the Twitter callback session-read path with an adapter-level regression test

## Verification
- bun run typecheck
- bun run lint
- bun run test:unit
- bun run test:nuxt
- bun run fmt:check
- bun run build
- bun run cf:check