### PR TITLE
Enhance item revalidation logic with force refresh option

### DIFF
--- a/server/api/items/owned-avatars.get.ts
+++ b/server/api/items/owned-avatars.get.ts
@@ -12,26 +12,51 @@ const query = z.object({
 export default authedSessionEventHandler<Item[]>(async ({ event, session, db }) => {
     const { limit } = await validateQuery(query)
 
-    const data = await db.query.items.findMany({
-        where: {
-            outdated: { eq: false },
-            category: { eq: 'avatar' },
-            setupItems: {
-                setup: {
-                    userId: { eq: session.user.id },
+    const [data, outdatedItems] = await Promise.all([
+        db.query.items.findMany({
+            where: {
+                outdated: { eq: false },
+                category: { eq: 'avatar' },
+                setupItems: {
+                    setup: {
+                        userId: { eq: session.user.id },
+                    },
                 },
             },
-        },
-        orderBy: {
-            createdAt: 'desc',
-        },
-        limit,
-    })
+            orderBy: {
+                createdAt: 'desc',
+            },
+            limit,
+        }),
 
-    if (data.length)
-        runAfterResponse(
-            Promise.all(data.map((item) => enqueueItemRevalidation(event, item, 'owned-avatars'))),
-        )
+        db.query.items.findMany({
+            where: {
+                outdated: { eq: true },
+                category: { eq: 'avatar' },
+                setupItems: {
+                    setup: {
+                        userId: { eq: session.user.id },
+                    },
+                },
+            },
+            columns: {
+                id: true,
+                platform: true,
+                updatedAt: true,
+            },
+            limit,
+        }),
+    ])
+
+    const { forceUpdateItem } = await getAppFlags()
+
+    runAfterResponse(
+        Promise.all(
+            [...data, ...outdatedItems].map((item) =>
+                enqueueItemRevalidation(event, item, 'owned-avatars', { force: forceUpdateItem }),
+            ),
+        ),
+    )
 
     return data
 })

--- a/server/api/setups/[id]/index.get.ts
+++ b/server/api/setups/[id]/index.get.ts
@@ -142,13 +142,19 @@ export default sessionEventHandler<Setup>(async ({ event, session, db }) => {
     const revalidationTasks: Promise<unknown>[] = []
     let failedItemsCount = 0
 
+    const { forceUpdateItem } = await getAppFlags()
+
     for (const setupItem of data.items) {
+        revalidationTasks.push(
+            enqueueItemRevalidation(event, setupItem.item, 'setup-detail', {
+                force: forceUpdateItem,
+            }),
+        )
+
         if (setupItem.item.outdated) {
             failedItemsCount++
             continue
         }
-
-        revalidationTasks.push(enqueueItemRevalidation(event, setupItem.item, 'setup-detail'))
 
         items.push({
             id: setupItem.item.id,

--- a/server/utils/getItem.ts
+++ b/server/utils/getItem.ts
@@ -32,6 +32,7 @@ interface GithubReadmeResponse {
 interface GetItemOptions {
     allowExternalResolution?: boolean
     beforeExternalResolution?: () => Promise<void>
+    forceRefresh?: boolean
 }
 
 const getGithubResource = <T>(repo: string, path = ''): Promise<T | null> => {
@@ -61,8 +62,19 @@ export default async (
 
     const { forceUpdateItem, allowedBoothCategoryId, specificItemCategories } = await getAppFlags()
 
-    const { fresh, cachedItem } = await resolveItemCache(db, id, provider, forceUpdateItem)
+    const forceRefresh = forceUpdateItem || options.forceRefresh === true
+
+    const { fresh, cachedItem, revalidationDue } = await resolveItemCache(
+        db,
+        id,
+        provider,
+        forceRefresh,
+    )
+
     if (fresh) return fresh
+
+    if (cachedItem && !revalidationDue)
+        throw serverError.notFound({ responseMessage: 'Item not found or not allowed' })
 
     const resolvedProvider = provider ?? cachedItem?.platform
     if (!resolvedProvider)
@@ -359,7 +371,7 @@ export const persistItem = async (
 export const resolveItemCache = async (
     db: ReturnType<typeof useDB>,
     id: string,
-    category: Platform | undefined,
+    platform: Platform | undefined,
     forceUpdate: boolean,
 ) => {
     const cachedItem =
@@ -393,25 +405,30 @@ export const resolveItemCache = async (
             },
         })) || null
 
-    if (cachedItem?.outdated && !forceUpdate)
-        throw serverError.notFound({
-            responseMessage: 'Item not found or not allowed',
-        })
+    const resolvedPlatform = platform ?? cachedItem?.platform
 
-    const resolvedCategory = category ?? cachedItem?.platform
+    const maxAgeMs = resolvedPlatform
+        ? resolvedPlatform === 'github'
+            ? GITHUB_ITEM_CACHE_DURATION_MS
+            : ITEM_CACHE_DURATION_MS
+        : undefined
 
-    const maxAgeMs = {
-        booth: ITEM_CACHE_DURATION_MS,
-        github: GITHUB_ITEM_CACHE_DURATION_MS,
-    }
+    const age =
+        cachedItem && maxAgeMs !== undefined
+            ? Date.now() - new Date(cachedItem.updatedAt).getTime()
+            : undefined
+
+    const revalidationDue =
+        forceUpdate ||
+        !cachedItem ||
+        (age !== undefined && maxAgeMs !== undefined && age >= maxAgeMs)
 
     const fresh =
-        !forceUpdate &&
-        resolvedCategory &&
-        cachedItem &&
-        Date.now() - new Date(cachedItem.updatedAt).getTime() < maxAgeMs[resolvedCategory]
-            ? cachedItem
-            : null
+        !forceUpdate && cachedItem && !cachedItem.outdated && !revalidationDue ? cachedItem : null
 
-    return { fresh, cachedItem }
+    return {
+        fresh,
+        cachedItem,
+        revalidationDue,
+    }
 }

--- a/server/utils/itemRevalidationQueue.ts
+++ b/server/utils/itemRevalidationQueue.ts
@@ -10,6 +10,7 @@ export interface ItemRevalidationMessage {
     platform: Platform
     reason: 'setup-detail' | 'owned-avatars'
     requestedAt: string
+    force?: boolean
 }
 
 type RevalidatableItem = Pick<Item, 'id' | 'platform'> & {
@@ -23,9 +24,15 @@ const getLockKey = (id: Item['id'], platform: Platform) =>
 
 const shouldUseQueue = () => !import.meta.dev && process.env.NODE_ENV !== 'test'
 
-export const isItemRevalidationDue = (item: Pick<RevalidatableItem, 'platform' | 'updatedAt'>) => {
+export const isItemRevalidationDue = (
+    item: Pick<RevalidatableItem, 'platform' | 'updatedAt'>,
+    force = false,
+) => {
+    if (force) return true
+
     const maxAgeMs =
         item.platform === 'github' ? GITHUB_ITEM_CACHE_DURATION_MS : ITEM_CACHE_DURATION_MS
+
     return Date.now() - new Date(item.updatedAt).getTime() >= maxAgeMs
 }
 
@@ -33,8 +40,9 @@ export const enqueueItemRevalidation = async (
     event: H3Event,
     item: RevalidatableItem,
     reason: ItemRevalidationMessage['reason'],
+    options: { force?: boolean } = {},
 ) => {
-    if (!shouldUseQueue() || !isItemRevalidationDue(item)) return false
+    if (!shouldUseQueue() || !isItemRevalidationDue(item, options.force)) return false
 
     const queue = getQueue(event)
     if (!queue) return false
@@ -51,7 +59,9 @@ export const enqueueItemRevalidation = async (
             platform: item.platform,
             reason,
             requestedAt: new Date().toISOString(),
+            force: options.force,
         } satisfies ItemRevalidationMessage)
+
         return true
     } catch (error) {
         await useStorage('cache').del(lockKey)
@@ -66,6 +76,7 @@ export const handleItemRevalidationMessage = async (message: ItemRevalidationMes
     try {
         const item = await getItem(undefined, db, message.id, message.platform, {
             allowExternalResolution: true,
+            forceRefresh: message.force === true,
         })
         persistedItemId = item.id
     } catch (error) {


### PR DESCRIPTION
Improve the item revalidation process by adding a force refresh option, allowing for more control over item updates. This change enhances the logic for determining when items need revalidation, ensuring that outdated items are handled appropriately.